### PR TITLE
Added the functionality to specify the StartupWMClass in mLauncher

### DIFF
--- a/main.py
+++ b/main.py
@@ -172,6 +172,7 @@ class Handler:
 		category=builder.get_object("comboboxtext-entry").get_text()
 		terminal=builder.get_object("switchTerminal").get_state()
 		keywords=builder.get_object("entryKeywords").get_text().strip()
+		wmclass=builder.get_object("entryWMclass").get_text().strip()
 		#check if the name contains nothing or only spaces
 		if name and executable:
 			if path and not os.path.isdir(path):
@@ -193,6 +194,7 @@ class Handler:
 				launcherString+="Name="+name+"\n"
 				launcherString+="Icon="+self.iconPath+"\n"
 				launcherString+="Keywords="+keywords+"\n"
+				launcherString+="StartupWMClass="+wmclass+"\n"
 				launcherString+=self.untouchableLines
 				if self.customSavePath:
 					self.savePath=self.customSavePath
@@ -284,6 +286,7 @@ class Handler:
 			category=builder.get_object("comboboxtext-entry")
 			terminal=builder.get_object("switchTerminal")
 			keywords=builder.get_object("entryKeywords")
+			wmclass=builder.get_object("entryWMclass")
 
 			self.resetUI()
 
@@ -342,6 +345,10 @@ class Handler:
 					keywords.set_text(lines[i].strip()[9:])
 					lines.pop(i)
 					skip[6]=True
+				elif lines[i].strip()[:15] == "StartupWMClass=" and not skip[7]:
+					wmclass.set_text(lines[i].strip()[15:])
+					lines.pop(i)
+					skip[7]=True
 				else:
 					self.untouchableLines+=lines.pop(i)
 		except:

--- a/ui.glade
+++ b/ui.glade
@@ -454,6 +454,45 @@ Author: Gabriele Musco
               </packing>
             </child>
             <child>
+              <object class="GtkBox" id="boxWMclass">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
+                <child>
+                  <object class="GtkLabel" id="labelWMclass">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">StartupWMClass:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="entryWMclass">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="secondary_icon_tooltip_text" translatable="yes">Used to relate specific windows to certain applications. For example to assign a custom icon to a Chromium webapp.</property>
+                    <property name="placeholder_text" translatable="yes">(Optional)</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">6</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkBox" id="boxIcon">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -569,7 +608,7 @@ Author: Gabriele Musco
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">6</property>
+                <property name="position">7</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
I mostly use mLauncher to create "Chromium webapps", i.e. `chromium --app="URL"` as executable.
While assigning icons to the .desktop file works for launching the app, it does not work at runtime, as it returns to the default Chromium icon. To fix that, the URL (without `http[s]://`) has to be added as `StartupWMClass`, which is now possible via mLauncher :wink:

:bulb: For the future one could even think about creating a single button "create Chrome/Chromium webapp" with a popup that handles URL processing, so that the user simply specifies the URL, name and icon. What do you think about that? 
