### PR TITLE
fixed bugs

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,8 @@ class App(Gtk.Application):
 		window.show_all()
 
 	def on_about_activate(self, *agrs):
-		builder.get_object("aboutdialog").show()
+		builder.get_object("aboutdialog").run()
+		builder.get_object("aboutdialog").hide()
 
 	def on_quit_activate(self, *args):
 		self.quit()
@@ -161,9 +162,6 @@ class Handler:
 
 	def on_radiobuttonIcon_group_changed(self, button):
 		self.updateRadios()
-
-	def onDeleteWindow(self, *args):
-		Gtk.main_quit(*args)
 
 	def buttonSave_clicked_cb(self, button):
 		name=builder.get_object("entryName").get_text().strip()

--- a/ui.glade
+++ b/ui.glade
@@ -1,25 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.19.0 
-
 Copyright (C) 2015 Gabriele Musco
-
 This file is part of mLauncher.
-
 mLauncher is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-
 mLauncher is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-
 You should have received a copy of the GNU General Public License
 along with mLauncher.  If not, see <http://www.gnu.org/licenses/>.
-
 Author: Gabriele Musco
-
 -->
 <interface domain="en_US">
   <requires lib="gtk+" version="3.16"/>
@@ -46,7 +39,6 @@ Author: Gabriele Musco
     <property name="can_focus">False</property>
     <property name="icon_name">gnome-panel-launcher</property>
     <property name="show_menubar">False</property>
-    <signal name="destroy" handler="onDeleteWindow" swapped="no"/>
     <child>
       <object class="GtkBox" id="boxContainer">
         <property name="visible">True</property>


### PR DESCRIPTION
Fixed close button on about dialog, and gtk_main_quit: error. Gapplication handles the exiting no need for Gtk.main.quit().
